### PR TITLE
JBIDE-14516 - 'Create Arquillian Deployment Method' dialog should default to 'null' 'Archive Name'

### DIFF
--- a/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/wizards/NewArquillianJUnitTestCaseDeploymentPage.java
+++ b/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/wizards/NewArquillianJUnitTestCaseDeploymentPage.java
@@ -193,7 +193,7 @@ public class NewArquillianJUnitTestCaseDeploymentPage extends WizardPage {
 		// FIXME 
 		methodNameText.setText("createDeployment");
 		archiveTypeCombo.select(0);
-		archiveNameText.setText("test");
+		archiveNameText.setText("");
 		beansXmlButton.setSelection(true);
 		
 		methodNameText.addModifyListener(new ModifyListener() {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-14516
'Create Arquillian Deployment Method' dialog should default to 'null' 'Archive Name'
