### PR TITLE
JBIDE-15241 - Bump parent pom version in root pom to 4.1.0.Final-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.1.0.CR1-SNAPSHOT</version>
+		<version>4.1.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>arquillian</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-15241
For JBIDE 4.1.0.Final: Bump parent pom version in root pom to 4.1.0.Final-SNAPSHOT [Arquillian]
