### PR TITLE
JBIDE-14778 - Fixing 'Generate deployment method'

### DIFF
--- a/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/utils/ArquillianUIUtil.java
+++ b/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/utils/ArquillianUIUtil.java
@@ -349,11 +349,15 @@ public class ArquillianUIUtil {
 			buffer.append(" )"); //$NON-NLS-1$
 		}
 
-		if (addBeansXml) {
+		if (addBeansXml && !ArquillianUIActivator.EAR.equals(archiveType)) {
 			addImport(imports, importsRewrite,
 					"org.jboss.shrinkwrap.api.asset.EmptyAsset"); //$NON-NLS-1$
 			buffer.append(delimiter);
-			buffer.append(".addAsManifestResource(EmptyAsset.INSTANCE, \"beans.xml\")"); //$NON-NLS-1$
+			if (ArquillianUIActivator.WAR.equals(archiveType)) {
+				buffer.append(".addAsWebInfResource(EmptyAsset.INSTANCE, \"beans.xml\")"); //$NON-NLS-1$
+			} else {
+				buffer.append(".addAsManifestResource(EmptyAsset.INSTANCE, \"beans.xml\")"); //$NON-NLS-1$
+			}
 		}
 
 		buffer.append(";").append(delimiter); //$NON-NLS-1$

--- a/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/wizards/NewArquillianJUnitTestCaseDeploymentPage.java
+++ b/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/wizards/NewArquillianJUnitTestCaseDeploymentPage.java
@@ -238,6 +238,7 @@ public class NewArquillianJUnitTestCaseDeploymentPage extends WizardPage impleme
 		}
 		archiveNameText.setText(""); //$NON-NLS-1$
 		beansXmlButton.setSelection(true);
+		beansXmlButton.setEnabled(archiveTypeCombo.getSelectionIndex() != EAR_INDEX);
 		
 		methodNameText.addModifyListener(new ModifyListener() {
 			
@@ -271,6 +272,7 @@ public class NewArquillianJUnitTestCaseDeploymentPage extends WizardPage impleme
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
+				beansXmlButton.setEnabled(archiveTypeCombo.getSelectionIndex() != EAR_INDEX);
 				refreshResourceViewer();
 			}
 		


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-14778
'Generate deployment method' uses wrong location for option 'add empty beans.xml' when war type is selected
