### PR TITLE
JBIDE-16603 - Type/name.extension validation doesn't work in 'Generate Deployment Method Dialog'

### DIFF
--- a/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/wizards/NewArquillianJUnitTestCaseDeploymentPage.java
+++ b/plugins/org.jboss.tools.arquillian.ui/src/org/jboss/tools/arquillian/ui/internal/wizards/NewArquillianJUnitTestCaseDeploymentPage.java
@@ -336,7 +336,7 @@ public class NewArquillianJUnitTestCaseDeploymentPage extends WizardPage impleme
 		String archiveName = archiveNameText.getText();
 		if (!archiveName.isEmpty()) {
 			String extension = "." + archiveTypeCombo.getText(); //$NON-NLS-1$
-			if (!archiveName.endsWith(extension) && archiveName.trim().length() <= 4) {
+			if (!archiveName.endsWith(extension) || archiveName.trim().length() <= 4) {
 				setErrorMessage("Invalid archive name");
 			}
 		}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-16603
Type/name.extension validation doesn't work in 'Generate Deployment Method Dialog'
