### PR TITLE
JBIDE-22865 - 3rd party caused FileNotFoundException below ContainerParser.getContainers

### DIFF
--- a/plugins/org.jboss.tools.arquillian.core/src/org/jboss/tools/arquillian/core/internal/container/ContainerParser.java
+++ b/plugins/org.jboss.tools.arquillian.core/src/org/jboss/tools/arquillian/core/internal/container/ContainerParser.java
@@ -103,7 +103,7 @@ public class ContainerParser {
 				File f =  getFile(new URL(CONTAINERS_JSON));
 				URL url;
 				if (f != null && f.isFile() && f.length() > 0) {
-					url = f.toURI().toURL();
+					url = f.toURL();
 				} else {
 					url = getUrlFromBundle();
 				}
@@ -126,7 +126,7 @@ public class ContainerParser {
 			if (f == null || !f.exists()) {
 				return getUrlFromBundle();
 			} else {
-				return f.toURI().toURL();
+				return f.toURL();
 			}
 		} catch (Exception e) {
 			ArquillianCoreActivator.log(e);


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-22865
3rd party caused FileNotFoundException below ContainerParser.getContainers